### PR TITLE
Remove typo

### DIFF
--- a/css/gruvbox-dark-medium.css
+++ b/css/gruvbox-dark-medium.css
@@ -217,7 +217,7 @@ h6 {
   color: #83c07c;               /**/
 }
 pre {
-  background-color: #3c3836/;   /**/
+  background-color: #3c3836;   /**/
   color: #ebdbb2;               /**/
   border: 1pt solid #a89984;    /**/
   padding: 1em;


### PR DESCRIPTION
"Error in parsing value for ‘background-color’.  Declaration dropped. gruvbox-dark-medium.css:221:28
Elements matching selector: pre"